### PR TITLE
Fix mismatching of sentence final punctuation

### DIFF
--- a/opuscleaner/filters/fix_sent_final_punct.json
+++ b/opuscleaner/filters/fix_sent_final_punct.json
@@ -1,0 +1,6 @@
+{
+    "type": "bilingual",
+    "description": "Fixes mismatched punctuation at the end of the sentences. Works for latin/cyrillic based languages, WILL BREAK CJK AND ANY LANGUAGE THAT USES NON ENGLISH LIKE SENTENCE ENDING TOKENS.",
+    "parameters": {},
+    "command": "./fix_sent_final_punct.py"
+}

--- a/opuscleaner/filters/fix_sent_final_punct.py
+++ b/opuscleaner/filters/fix_sent_final_punct.py
@@ -14,6 +14,9 @@ for line in sys.stdin:
         src = src[:-2] + src[-1]
     if len(trg) >= 2 and trg[-1] in my_punct and trg[-2] == " " and trg[-1] != '»' and trg[-1] != '«':
         trg = trg[:-2] + trg[-1]
+    # Sometimes two punctuation marks are swapped...
+    if len(src) >=2 and len(trg) >= 2 and src[-2] == trg[-1] and src[-1] == trg[-2]:
+       trg = trg[:-2] + src[-2] + src[-1]
 
     # check for the french quotes special case
     if (src[-1] == '»' or src[-1] == '«') and trg[-1] not in my_punct:

--- a/opuscleaner/filters/fix_sent_final_punct.py
+++ b/opuscleaner/filters/fix_sent_final_punct.py
@@ -24,6 +24,8 @@ for line in sys.stdin:
         trg = trg + src[-1]
     elif trg[-1] in my_punct and src[-1] not in my_punct:
         src = src + trg[-1]
-    elif trg[-1] in my_punct and src[-1] in my_punct and src[-1] != trg[-1] and src[-1] != '»' and src[-1] != '«' and trg[-1] != '»' and trg[-1] != '«':
+    # Final case. Fix mismatched punctuation on the src and trg. EXCEPT in cases like french quotes. And in cases where we have emdash at the front, as it means spech
+    elif trg[-1] in my_punct and src[-1] in my_punct and src[-1] != trg[-1] and src[-1] != '»' \
+and src[-1] != '«' and trg[-1] != '»' and trg[-1] != '«' and src[0] != '–' and trg[0] != '–' and src[0] != '—' and trg[0] != '—':
         trg = trg[:-1] + src[-1]
     print(src + '\t' + trg)

--- a/opuscleaner/filters/fix_sent_final_punct.py
+++ b/opuscleaner/filters/fix_sent_final_punct.py
@@ -5,11 +5,16 @@ my_punct = ['!', '"', '#', '$', '%', '&', "'", '(', ')', '*', '+', ',', '.', '/'
 
 for line in sys.stdin:
     src, trg = line.rstrip("\r\n").split("\t")
+    if len(src) == 0 or len(trg) == 0:
+        print(src + '\t' + trg)
+        continue
+
     # Sometimes we have a space between the final letter and the punctuation
-    if src[-1] in my_punct and src[-2] == " ":
+    if len(src) >= 2 and src[-1] in my_punct and src[-2] == " ":
         src = src[:-2] + src[-1]
-    if trg[-1] in my_punct and trg[-2] == " ":
+    if len(trg) >= 2 and trg[-1] in my_punct and trg[-2] == " ":
         trg = trg[:-2] + trg[-1]
+
     # check for the french quotes special case
     if src[-1] == '»' or src[-1] == '«' and trg[-1] not in my_punct:
         trg = trg + '"'

--- a/opuscleaner/filters/fix_sent_final_punct.py
+++ b/opuscleaner/filters/fix_sent_final_punct.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import sys
+
+my_punct = ['!', '"', '#', '$', '%', '&', "'", '(', ')', '*', '+', ',', '.', '/', ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '^', '_', '`', '{', '|', '}', '~', '»', '«', '“', '”']
+
+for line in sys.stdin:
+    src, trg = line.rstrip("\r\n").split("\t")
+    # Sometimes we have a space between the final letter and the punctuation
+    if src[-1] in my_punct and src[-2] == " ":
+        src = src[:-2] + src[-1]
+    if trg[-1] in my_punct and trg[-2] == " ":
+        trg = trg[:-2] + trg[-1]
+    # check for the french quotes special case
+    if src[-1] == '»' or src[-1] == '«' and trg[-1] not in my_punct:
+        trg = trg + '"'
+    elif trg[-1] == '»' or trg[-1] == '«' and src[-1] not in my_punct:
+        src = src + '"'
+    elif src[-1] in my_punct and trg[-1] not in my_punct:
+        trg = trg + src[-1]
+    elif trg[-1] in my_punct and src[-1] not in my_punct:
+        src = src + trg[-1]
+    elif trg[-1] in my_punct and src[-1] in my_punct and src[-1] != trg[-1]:
+        trg = trg[:-1] + src[-1]
+    print(src + '\t' + trg)

--- a/opuscleaner/filters/fix_sent_final_punct.py
+++ b/opuscleaner/filters/fix_sent_final_punct.py
@@ -17,6 +17,12 @@ for line in sys.stdin:
     # Sometimes two punctuation marks are swapped...
     if len(src) >=2 and len(trg) >= 2 and src[-2] == trg[-1] and src[-1] == trg[-2]:
        trg = trg[:-2] + src[-2] + src[-1]
+    # Sometimes they are swapped with space around eg SPACE». -> .SPACE»
+    if len(src) >=3 and src[-1] in my_punct and src[-2] == '»' and src[-3] == ' ':
+       src = src[:-3] + src[-1] + ' ' + src[-2]
+    if len(trg) >=3 and trg[-1] in my_punct and trg[-2] == '»' and trg[-3] == ' ':
+       trg = trg[:-3] + trg[-1] + ' ' + trg[-2]
+
 
     # check for the french quotes special case
     if (src[-1] == '»' or src[-1] == '«') and trg[-1] not in my_punct:

--- a/opuscleaner/filters/fix_sent_final_punct.py
+++ b/opuscleaner/filters/fix_sent_final_punct.py
@@ -9,10 +9,10 @@ for line in sys.stdin:
         print(src + '\t' + trg)
         continue
 
-    # Sometimes we have a space between the final letter and the punctuation
-    if len(src) >= 2 and src[-1] in my_punct and src[-2] == " ":
+    # Sometimes we have a space between the final letter and the punctuation, which is wrong except if using french quotes
+    if len(src) >= 2 and src[-1] in my_punct and src[-2] == " " and src[-1] != '»' and src[-1] != '«':
         src = src[:-2] + src[-1]
-    if len(trg) >= 2 and trg[-1] in my_punct and trg[-2] == " ":
+    if len(trg) >= 2 and trg[-1] in my_punct and trg[-2] == " " and trg[-1] != '»' and trg[-1] != '«':
         trg = trg[:-2] + trg[-1]
 
     # check for the french quotes special case
@@ -24,6 +24,6 @@ for line in sys.stdin:
         trg = trg + src[-1]
     elif trg[-1] in my_punct and src[-1] not in my_punct:
         src = src + trg[-1]
-    elif trg[-1] in my_punct and src[-1] in my_punct and src[-1] != trg[-1]:
+    elif trg[-1] in my_punct and src[-1] in my_punct and src[-1] != trg[-1] and src[-1] != '»' and src[-1] != '«' and trg[-1] != '»' and trg[-1] != '«':
         trg = trg[:-1] + src[-1]
     print(src + '\t' + trg)

--- a/opuscleaner/filters/fix_sent_final_punct.py
+++ b/opuscleaner/filters/fix_sent_final_punct.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import sys
 
-my_punct = ['!', '"', '#', '$', '%', '&', "'", '(', ')', '*', '+', ',', '.', '/', ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '^', '_', '`', '{', '|', '}', '~', '»', '«', '“', '”']
+my_punct = {'!', '"', '#', '$', '%', '&', "'", '(', ')', '*', '+', ',', '.', '/', ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '^', '_', '`', '{', '|', '}', '~', '»', '«', '“', '”'}
 
 for line in sys.stdin:
     src, trg = line.rstrip("\r\n").split("\t")
@@ -16,9 +16,9 @@ for line in sys.stdin:
         trg = trg[:-2] + trg[-1]
 
     # check for the french quotes special case
-    if src[-1] == '»' or src[-1] == '«' and trg[-1] not in my_punct:
+    if (src[-1] == '»' or src[-1] == '«') and trg[-1] not in my_punct:
         trg = trg + '"'
-    elif trg[-1] == '»' or trg[-1] == '«' and src[-1] not in my_punct:
+    elif (trg[-1] == '»' or trg[-1] == '«') and src[-1] not in my_punct:
         src = src + '"'
     elif src[-1] in my_punct and trg[-1] not in my_punct:
         trg = trg + src[-1]


### PR DESCRIPTION
Fixes cases where punctuation doesn't match on src/trg OR cases where there's an extra space in before the punctuation.

Examples converts these lines
```
In the name of Allah the Most Gracious, the Most Merciful	Au nom d'Allah le Tout Miséricordieux, le Très Miséricordieux,
In the Name of Allah, the Compassionate, the Merciful!	Au nom d'Allah, le tout Miséricordieux et très Miséricordieux
In the Holy name of Allah most gracious	A Nom d'Allah le Très Miséricordieux, le Tout Miséricordieux,
In the holy name of Allah most gracious,	Au nom D'Allah le Tout Miséricordieux, le Très Miséricordieux,
To those who are not aware of searchEstate;	À ceux qui ne se rendent pas compte du searchEstate ;
```
into:
```
In the name of Allah the Most Gracious, the Most Merciful,	Au nom d'Allah le Tout Miséricordieux, le Très Miséricordieux,
In the Name of Allah, the Compassionate, the Merciful!	Au nom d'Allah, le tout Miséricordieux et très Miséricordieux!
In the Holy name of Allah most gracious,	A Nom d'Allah le Très Miséricordieux, le Tout Miséricordieux,
In the holy name of Allah most gracious,	Au nom D'Allah le Tout Miséricordieux, le Très Miséricordieux,
To those who are not aware of searchEstate;	À ceux qui ne se rendent pas compte du searchEstate;
```