### PR TITLE
Cancelable parallel

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,6 @@ name: Build and upload to PyPI
 
 on:
   push:
-  pull_request:
   release:
     types:
       - published

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,26 @@ jobs:
           name: frontend
           path: frontend/dist/
 
+  run_tests:
+    needs: [build_frontend]
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v3
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: frontend
+          path: frontend/dist
+      
+      - name: Install
+        run: python3 -m pip install .
+
+      - name: Run unittest
+        run: python3 -m unittest discover -s test
+
   build_sdist:
     needs: [build_frontend]
     name: Build source distribution

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ OpusCleaner is a machine translation/language model data cleaner and training sc
 ## Cleaner
 The cleaner bit takes care of downloading and cleaning multiple different datasets and preparing them for translation.
 
+```sh
+opuscleaner-clean --parallel 4 data/train-parts/dataset.filter.json | gzip -c > clean.gz
+```
+
 ### Installation for cleaning
 If you just want to use OpusCleaner for cleaning, you can install it from PyPI, and then run it
 
@@ -41,6 +45,7 @@ Compare the dataset at different stages of filtering to see what the impact is o
 ### Paths
 - `data/train-parts` is scanned for datasets. You can change this by setting the `DATA_PATH` environment variable, the default is `data/train-parts/*.*.gz`.
 - `filters` should contain filter json files. You can change the `FILTER_PATH` environment variable, the default is `<PYTHON_PACKAGE>/filters/*.json`.
+
 
 ### Installation for development
 ```sh

--- a/opuscleaner/_util.py
+++ b/opuscleaner/_util.py
@@ -32,13 +32,16 @@ class ThreadPool:
 
     def start(self, func, *args, **kwargs):
         thread_id = len(self.threads)
-        self.threads[thread_id] = Thread(target=_thread_pool_worker, kwargs={
-            "id": thread_id,
-            "exc_queue": self.queue,
-            "target": func,
-            "args": args,
-            "kwargs": kwargs,
-        }, daemon=True)
+        self.threads[thread_id] = Thread(
+            target=_thread_pool_worker,
+            kwargs={
+                "id": thread_id,
+                "exc_queue": self.queue,
+                "target": func,
+                "args": args,
+                "kwargs": kwargs,
+            },
+            name=func.__name__)
         self.threads[thread_id].start()
 
     def join(self):

--- a/opuscleaner/_util.py
+++ b/opuscleaner/_util.py
@@ -94,7 +94,7 @@ class CancelableQueue(Generic[T]):
     def get(self) -> T:
         """blocking get(). Either returns an item from the queue, or raises
         `Cancelled`.
-        """"
+        """
         with self.cv:
             self.cv.wait_for(lambda: self.cancelled or self.size > 0)
             if self.cancelled:

--- a/opuscleaner/_util.py
+++ b/opuscleaner/_util.py
@@ -1,5 +1,8 @@
-from typing import TypeVar, Optional
-from threading import Thread
+from typing import TypeVar, Optional, Generic
+from threading import Thread, Condition
+from collections import deque
+from queue import SimpleQueue
+
 
 T = TypeVar("T")
 
@@ -9,20 +12,100 @@ def none_throws(optional: Optional[T], message: str = "Unexpected `None`") -> T:
     return optional
 
 
-class RaisingThread(Thread):
-    """Thread that will raise any uncaught exceptions in the thread in the
-    parent once it joins again."""
+def _thread_pool_worker(id:int, exc_queue:SimpleQueue, target, args, kwargs):
+    try:
+        target(*args, **kwargs)
+        exc_queue.put((id, None))
+    except Exception as exc:
+        exc_queue.put((id, exc))
 
-    exception: Optional[Exception]
 
-    def run(self):
-        self.exception = None
-        try:
-            super().run()
-        except Exception as exc:
-            self.exception = exc
+class ThreadPool:
+    """Threadpool that can join() all started threads at the same time, but if
+    any of those threads got caught in an exception, join() will reraise that
+    exception as soon as it is received. It is then up to you to stop any other
+    threads. This pool will wait for them when it exits the context.
+    """
+    def __init__(self):
+        self.threads = {}
+        self.queue = SimpleQueue()
 
-    def join(self, timeout:float=None):
-        super().join(timeout=timeout)
-        if self.exception is not None:
-            raise self.exception
+    def start(self, func, *args, **kwargs):
+        thread_id = len(self.threads)
+        self.threads[thread_id] = Thread(target=_thread_pool_worker, kwargs={
+            "id": thread_id,
+            "exc_queue": self.queue,
+            "target": func,
+            "args": args,
+            "kwargs": kwargs,
+        }, daemon=True)
+        self.threads[thread_id].start()
+
+    def join(self):
+        while len(self.threads) > 0:
+            thread_id, exc = self.queue.get()
+            self.threads[thread_id].join()
+            del self.threads[thread_id]
+            if exc is not None:
+                raise exc
+
+    def __enter__(self):
+        return self
+    
+    def __exit__(self, *args, **kwargs):
+        for thread in self.threads.values():
+            thread.join()
+        self.threads = {}
+
+
+class Cancelled(Exception):
+    """Error raised by CancelableQueue's `put()` or `get()` when `cancel()` was
+    called.
+    """
+    pass
+
+
+T = TypeVar('T')
+
+class CancelableQueue(Generic[T]):
+    """SimpleQueue, but when cancel() is called it will release all blocking
+    put() and get() calls and raise `Cancelled`. Also much worse performance
+    than SimpleQueue so don't use for heavy workloads plz.
+    """
+    def __init__(self, capacity:Optional[int]=None):
+        self.capacity = capacity
+        self.size = 0
+        self.queue = deque()
+        self.cv = Condition()
+        self.cancelled = False
+
+    def put(self, item: T):
+        """put() blocks until there's space on the queue. Can raise `Cancelled`
+        when `cancel()` was called.
+        """
+        with self.cv:
+            self.cv.wait_for(lambda: self.cancelled or self.capacity is None or self.size < self.capacity)
+            if self.cancelled:
+                raise Cancelled()
+            self.queue.append(item)
+            self.size += 1
+            self.cv.notify()
+
+    def get(self) -> T:
+        """blocking get(). Either returns an item from the queue, or raises
+        `Cancelled`.
+        """"
+        with self.cv:
+            self.cv.wait_for(lambda: self.cancelled or self.size > 0)
+            if self.cancelled:
+                raise Cancelled()
+            self.size -= 1
+            item = self.queue.popleft()
+            self.cv.notify()
+        return item
+    
+    def cancel(self):
+        """Makes all calls to `get()` and `put()` raise `Cancelled()`."""
+        with self.cv:
+            self.cancelled = True
+            self.cv.notify_all()    

--- a/opuscleaner/clean.py
+++ b/opuscleaner/clean.py
@@ -55,8 +55,6 @@ def babysit_child(n: int, child: Popen, name: str, print_queue: PrintQueue, ctrl
 
     child.wait()
 
-    print_queue.put(f'[run.py] {name} exited with status code {child.returncode}\n'.encode())
-
     ctrl_queue.put((n, child.returncode))
 
 
@@ -250,7 +248,7 @@ class Pipeline:
             if not is_last_step and not tee:
                 stdin = none_throws(child.stdout)
 
-            pool.print_queue.put(f'[run.py] step {pool.name}{i}/{step.name}: Started {step.command}\n'.encode())
+            pool.print_queue.put(f'[run.py] step {pool.name}{i}/{step.name}: Started {step.command} (pid {child.pid})\n'.encode())
 
             # If we are tee-ing for debug, shunt the output to a separate file
             # TODO: uncompressed at the moment. Might be trouble.

--- a/opuscleaner/logging.py
+++ b/opuscleaner/logging.py
@@ -1,0 +1,226 @@
+import sys
+import time
+from collections import deque
+from functools import wraps
+from itertools import count
+from json import JSONEncoder
+from threading import Thread, get_ident, main_thread
+from queue import SimpleQueue
+from typing import Protocol, Iterable, Optional, TextIO
+from uuid import uuid1, UUID
+from contextlib import ExitStack
+
+
+def iter_queue(queue):
+	while True:
+		task = queue.get()
+		if task is None:
+			break
+		yield task
+
+
+class Span:
+	def __init__(self, logger, name, extra=dict()):
+		self.logger = logger
+		self.name = name
+		self.extra =extra
+		self.span = None
+
+	def __enter__(self) -> 'Span':
+		self.span = self.logger.push(self.name, **self.extra, type='span', start=time.monotonic_ns())
+		return self
+
+	def __exit__(self, typ, value, traceback) -> None:
+		span = self.logger.pop()
+		assert self.span == span
+		self.logger.update(self.span, end=time.monotonic_ns(), error=repr(value) if value is not None else None)
+
+	def event(self, name, **kwargs) -> UUID:
+		return self.logger.event(name, type='event', parent=self.span, **kwargs)
+
+
+class Handler(Protocol):
+	def emit(self, record:dict) -> None:
+		pass
+
+
+class FallbackJSONEncoder(JSONEncoder):
+	def default(self, obj):
+		return str(obj)
+
+
+class NullHandler(Handler):
+	def emit(self, record:dict) -> None:
+		pass
+
+
+class StreamHandler(Handler):
+	def __init__(self, stream):
+		self.stream = stream
+		self.encoder = FallbackJSONEncoder()
+
+	def emit(self, record:dict) -> None:
+		for chunk in self.encoder.iterencode(record):
+			self.stream.write(chunk)
+		self.stream.write('\n')
+
+
+def _queue_to_handler(queue: SimpleQueue, handler: Handler):
+	for record in iter_queue(queue):
+		handler.emit(record)
+
+
+class ThreadEmitter(Handler):
+	def __init__(self, queue):
+		self.queue = queue
+
+	def emit(self, record:dict):
+		self.queue.put(record)
+
+
+class ThreadReceiver(Handler):
+	def __init__(self, handler:Handler):
+		self.handler = handler
+		self.queue = SimpleQueue()
+
+	def __enter__(self):
+		self.thread = Thread(target=_queue_to_handler, args=[self.queue, self.handler])
+		self.thread.start()
+		return self
+
+	def __exit__(self, *args):
+		self.queue.put(None)
+		self.thread.join()
+
+	def make_handler(self):
+		return ThreadEmitter(self.queue)
+
+
+class Logger:
+	handler: Handler
+	serial: Iterable[int]
+	stack: deque[UUID]
+
+	def __init__(self, handler:Handler):
+		self.handler = handler
+		self.serial = count()
+		self.stack = deque()
+
+	def span(self, name:str, **kwargs) -> Span:
+		return Span(self, name, kwargs)
+
+	def event(self, name:str, **kwargs) -> UUID:
+		event_id = uuid1(get_ident(), next(self.serial))
+		self.handler.emit({
+			'id': event_id,
+			'parent': self.stack[-1] if len(self.stack) > 0 else None,
+			'name': name,
+			**kwargs,
+		})
+		return event_id
+
+	def update(self, event_id:UUID, **kwargs) -> None:
+		self.handler.emit({
+			'id': event_id,
+			**kwargs
+		})
+
+	def push(self, name:str, **kwargs) -> UUID:
+		event_id = self.event(name, **kwargs)
+		self.stack.append(event_id)
+		return event_id
+
+	def pop(self) -> UUID:
+		return self.stack.pop()
+
+
+_main_thread_id = main_thread().ident
+
+_context = None
+
+
+class Context:
+	def __init__(self, *, file:Optional[TextIO]=None):
+		if file:
+			self.handler = StreamHandler(file)
+		else:
+			self.handler = NullHandler()
+
+		self.receiver = ThreadReceiver(self.handler)
+
+		self.loggers = {
+			_main_thread_id: Logger(self.handler)
+		}
+
+
+	def get_logger(self):
+		thread_id = get_ident()
+
+		if thread_id not in self.loggers:
+			self.loggers[thread_id] = Logger(self.receiver.make_handler())
+			self.loggers[thread_id].stack = deque(self.loggers[_main_thread_id].stack) # TODO what about threads starting threads?
+
+		return self.loggers[thread_id]
+
+	def __enter__(self):
+		global _context
+		assert _context is None
+		self.receiver.__enter__()
+		_context = self
+		return self
+
+	def __exit__(self, *args, **kwargs):
+		global _context
+		assert _context is self
+		self.receiver.__exit__()
+		_context = None
+
+
+def get_logger():
+	return _context.get_logger()
+
+
+def event(name:str, **kwargs) -> UUID:
+	return get_logger().event(name, **kwargs)
+
+
+def span(name:str, **kwargs) -> Span:
+	return get_logger().span(name, **kwargs)
+
+
+def trace(fn, name=None):
+	if name is None:
+		name = fn.__name__
+	@wraps(fn)
+	def wrapper(*args, **kwargs):
+		with get_logger().span(name):
+			return fn(*args, **kwargs)
+	return wrapper
+
+
+def trace_context(cls, name=None):
+	if name is None:
+		name = cls.__name__
+
+	class Wrapper(cls):
+		__span: Span
+
+		def __enter__(self):
+			self.__span = get_logger().span(name).__enter__()
+			super().__enter__()
+			return self
+
+		def __exit__(self, *args, **kwargs):
+			self.__span.event('__exit__')
+			try:
+				super().__exit__(*args, **kwargs)
+			finally:
+				self.__span.__exit__(*args, **kwargs)
+
+	return Wrapper
+
+
+def update(**kwargs):
+	logger = get_logger()
+	event_id = logger.stack[-1]
+	logger.update(event_id, **kwargs)

--- a/test/test_clean.py
+++ b/test/test_clean.py
@@ -17,6 +17,11 @@ FILES = [
 	"bible-uedin-v1.de-en.en.gz"
 ]
 
+SCENARIOS = {
+	'single': [],
+	'parallel': ['--parallel', '2', '--batch-size', '32000'], # parallel
+}
+
 
 class TestClean(unittest.TestCase):
 	def _run(self, args:List[str], **kwargs):
@@ -75,9 +80,9 @@ class TestClean(unittest.TestCase):
 			json.dump(config, fh)
 			fh.flush()
 
-			for mode in [[], ['--parallel', '1']]:
+			for mode, args in SCENARIOS.items():
 				with self.subTest(mode=mode):
-					out, err, retval = self._run([*mode, fh.name])
+					out, err, retval = self._run([*args, fh.name])
 					self.assertEqual(out.count(b'\n'), 0)
 					self.assertNotEqual(retval, 0)
 
@@ -110,14 +115,14 @@ class TestClean(unittest.TestCase):
 					)
 				fdata.flush()
 
-				for mode in [[], ['--parallel', '1']]:
+				for mode, args in SCENARIOS.items():
 					with self.subTest(mode=mode):
 						# Reset dataset input
 						fdata.seek(0)
 
 						# Run cleaner with `--input -` and pass the data through stdin
 						proc_clean = subprocess.Popen(
-							args=[sys.executable, '-m', 'opuscleaner.clean', *mode, '--input', '-', fconf.name, 'de', 'en'],
+							args=[sys.executable, '-m', 'opuscleaner.clean', *args, '--input', '-', fconf.name, 'de', 'en'],
 							cwd=TEST_CWD,
 							env={
 								'PYTHONPATH': os.path.join(os.path.dirname(__file__), '..') # so it can find opuscleaner code

--- a/test/test_col.py
+++ b/test/test_col.py
@@ -25,6 +25,13 @@ TEST_INPUT_SANE = "".join([
 ])
 
 
+TEST_INPUT_COL_MISSING = "".join([
+	*TEST_INPUT,
+	"single-col\n",
+	*TEST_INPUT_SANE
+])
+
+
 class TestCol(unittest.TestCase):
 	def _run(self, args:List[str], input:str) -> Tuple[str,str,int]:
 		proc = subprocess.Popen(COL_PY + args,
@@ -85,7 +92,7 @@ class TestCol(unittest.TestCase):
 		""")
 
 		out, err, retval = self._run(['0', sys.executable, '-c', overproduce], TEST_INPUT)
-		self.assertIn('Subprocess produced more lines of output than it was given.', err)
+		self.assertIn('subprocess produced more lines of output than it was given', err)
 		self.assertNotEqual(retval, 0)
 
 	def test_underproduce(self):
@@ -98,7 +105,7 @@ class TestCol(unittest.TestCase):
 		""")
 
 		out, err, retval = self._run(['0', sys.executable, '-c', underproduce], TEST_INPUT)
-		self.assertIn('Subprocess produced fewer lines than it was given.', err)
+		self.assertIn('subprocess produced fewer lines than it was given', err)
 		self.assertNotEqual(retval, 0)
 
 	def test_error_incorrect_subprocess(self):
@@ -122,5 +129,17 @@ class TestCol(unittest.TestCase):
 
 		out, err, retval = self._run(['0', sys.executable, '-c', underproduce], TEST_INPUT)
 		self.assertEqual(retval, 42)
-		self.assertIn('Subprocess exited with status code 42', err)
+		self.assertIn('subprocess exited with status code 42', err)
 
+	def test_error_col_missing(self):
+		"""A missing column in the input should raise an error"""
+		reproduce = dedent("""
+			import sys
+			for line in sys.stdin:
+				sys.stdout.write(line)
+		""")
+
+		out, err, retval = self._run(['1', sys.executable, '-u', '-c', reproduce], TEST_INPUT_COL_MISSING)
+		self.assertEqual(retval, 1)
+		self.assertIn('line does not contain enough columns', err)
+		


### PR DESCRIPTION
Fix for the non-quiting beviour of #116.

This adds a ThreadPool and a CancelableQueue.

The CancelableQueue combines a blocking queue with a stop signal. The problem is that the worker threads can only be interrupted when they're blocking on getting work from a queue, or putting results in a queue. This queue then has interruptible `get()` and `put()` methods.

The ThreadPool class is a better implementation of RaisingThread, where `TheadPool.join()` will behave more like a `select()` on sockets and raise an error as soon as any of the threads encountered an exception.

The general idea is that we start all threads as if everything will be allright, putting them in the thread pool. Then we wait for any of them to crash (or all of them to finish without exceptions). If any of them crashes, we call `cancel()` on the queues so that all the other threads also abort their loops. Then, because we're exiting the context of the ThreadPool, we'll wait for them to finish up nicely so that stuff like `try ... finally` still works as expected.

It is a contious decision that I don't care about exceptions in any of the other threads once I caught one in one of the threads in the threadpool. You can call `join()` multiple times until it exists without throwing, but in OpusCleaner just one error is already one too many or something.
