### PR TITLE
Improve num_mismatch filter

### DIFF
--- a/opuscleaner/col.py
+++ b/opuscleaner/col.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python3
 import sys
-import os
-import signal
-from traceback import print_exc
 from subprocess import Popen, PIPE
 from threading import Thread
 from queue import SimpleQueue
-from typing import Optional, TypeVar, List
-from functools import wraps
+from typing import Optional, TypeVar
 
 
 queue = SimpleQueue() # type: SimpleQueue[list[bytes]]
@@ -33,7 +29,7 @@ class RaisingThread(Thread):
 		except Exception as exc:
 			self.exception = exc
 
-	def join(self, timeout:float=None):
+	def join(self, timeout:Optional[float]=None):
 		super().join(timeout=timeout)
 		if self.exception is not None:
 			raise self.exception

--- a/opuscleaner/filters/num_mismatch.py
+++ b/opuscleaner/filters/num_mismatch.py
@@ -31,7 +31,7 @@ def filter_numerical_mismatch(fin: TextIO, fout: TextIO, ratio: float, *, debug:
 		nums_left, nums_right = (set(map(normalize, re.finditer(NUM_EXPR, col))) for col in cols[:2])
 
 		# Only bother calculating the ratio if there were any numbers to begin with
-		if nums_left and nums_right:
+		if nums_left or nums_right:
 			overlap = nums_left & nums_right
 			difference = nums_left ^ nums_right
 

--- a/opuscleaner/filters/num_mismatch.py
+++ b/opuscleaner/filters/num_mismatch.py
@@ -5,8 +5,21 @@ import sys
 from typing import Match, TextIO
 
 
+NUM_EXPR = re.compile(r"""
+	(?:
+		(?P<sign>(?:(?<=\s)|^)[-+])  # start with a sign if it is not attached to a word, i.e. not - in tid-30
+		|\b                          # or start with a word boundary, i.e. not just30
+	)
+	(?:0*)                         # allow for 0 prefixes which we then ignore when comparing
+	(?P<value>\d+                  # digits before the first comma or dot
+		(?:[\.,]\d+)*                # allow commas or dots, i.e. 300,000.0 but not 3,,,5
+	)
+	\b                             # disallow 30beep, but also 30th and 1st #TODO
+""", re.X)
+
+
 def normalize(numstr:Match) -> str:
-	return numstr['sign'] + re.sub(r'[^\d]+', '*', numstr['value']) # ignore the decimal and digit separators
+	return (numstr['sign'] or '') + re.sub(r'[^\d]+', '*', numstr['value']) # ignore the decimal and digit separators
 
 
 def filter_numerical_mismatch(fin: TextIO, fout: TextIO, ratio: float, *, debug: bool = False):
@@ -15,7 +28,7 @@ def filter_numerical_mismatch(fin: TextIO, fout: TextIO, ratio: float, *, debug:
 
 		assert len(cols) >= 2
 
-		nums_left, nums_right = (set(map(normalize, re.finditer(r'(?P<sign>[-+]?)(?:0*)(?P<value>\d+(?:[\.,]\d+)*)', col))) for col in cols[:2])
+		nums_left, nums_right = (set(map(normalize, re.finditer(NUM_EXPR, col))) for col in cols[:2])
 
 		# Only bother calculating the ratio if there were any numbers to begin with
 		if nums_left and nums_right:

--- a/opuscleaner/filters/num_mismatch.py
+++ b/opuscleaner/filters/num_mismatch.py
@@ -38,9 +38,10 @@ def filter_numerical_mismatch(fin: TextIO, fout: TextIO, ratio: float, *, debug:
 			# Big > 1.0 number if lots of overlap, small < 1.0 number if lots of differences
 			line_ratio = (len(overlap) + 1) / (len(difference) + 1)
 
+			if debug:
+				print(f"{len(overlap)} / {len(difference)} : {overlap!r} | {difference!r}", file=sys.stderr)
+
 			if line_ratio < ratio:
-				if debug:
-					print(f"{len(overlap)} / {len(difference)} : {overlap!r} | {difference!r}", file=sys.stderr)
 				continue
 
 		fout.write(line)

--- a/opuscleaner/filters/test_num_mismatch.py
+++ b/opuscleaner/filters/test_num_mismatch.py
@@ -46,3 +46,11 @@ class TestNumMismatch(unittest.TestCase):
 		self.assertReject('The current temp is -7.5 degrees\tI walked 7.5 miles', 1.0)
 		self.assertReject('The difference is +7.5 degrees\tI walked 7.5 miles', 1.0) # questionable?
 		self.assertReject('The current temp is -7.5 degrees\tI changed the value by +7.5', 1.0)
+
+	def test_word_boundary(self):
+		self.assertAccept('I am a 30something\tThat just40 should be ignored', 1.0)
+	
+	def test_word_boundary_dash(self):
+		self.assertAccept('-30 is the number\tThe number -30', 1.0)
+		self.assertAccept('The-number-30\tThe number 30', 1.0)
+		self.assertReject('Beep-30\tThe number is -30', 1.0)

--- a/test/test_col.py
+++ b/test/test_col.py
@@ -31,6 +31,12 @@ TEST_INPUT_COL_MISSING = "".join([
 	*TEST_INPUT_SANE
 ])
 
+TEST_INPUT_COL_OVERFLOW = "".join([
+	*TEST_INPUT,
+	"triple-col\ttriple-col\ttriple-col\n",
+	*TEST_INPUT_SANE
+])
+
 
 class TestCol(unittest.TestCase):
 	def _run(self, args:List[str], input:str) -> Tuple[str,str,int]:
@@ -141,5 +147,17 @@ class TestCol(unittest.TestCase):
 
 		out, err, retval = self._run(['1', sys.executable, '-u', '-c', reproduce], TEST_INPUT_COL_MISSING)
 		self.assertEqual(retval, 1)
-		self.assertIn('line does not contain enough columns', err)
+		self.assertIn('line contains a different number of fields', err)
+		
+	def test_error_col_overflow(self):
+		"""A line with too many columns should raise an error"""
+		reproduce = dedent("""
+			import sys
+			for line in sys.stdin:
+				sys.stdout.write(line)
+		""")
+
+		out, err, retval = self._run(['1', sys.executable, '-u', '-c', reproduce], TEST_INPUT_COL_OVERFLOW)
+		self.assertEqual(retval, 1)
+		self.assertIn('line contains a different number of fields', err)
 		


### PR DESCRIPTION
Fixes #98.

If you want to play with the regex: https://regex101.com/r/choHwO/1

Questions I have though:
- I added a boundary test at the end of the number to skip numbers in text like `30something`. But this now also ignores `2nd`.
- I removed the condition that there had to be numbers on both sides of the bitext to even consider looking at the ratio.