### PR TITLE
Update remove_empty_lines.json

### DIFF
--- a/opuscleaner/filters/remove_empty_lines.json
+++ b/opuscleaner/filters/remove_empty_lines.json
@@ -1,6 +1,6 @@
 {
     "description": "Remove lines that are empty or just whitespace on either side",
     "type": "bilingual",
-    "command": "grep -avE '^\\s*\\t|\\t\\s*$'",
+    "command": "grep -avP '^\\s*\\t|\\t\\s*$'",
     "parameters": {}
 }


### PR DESCRIPTION
This was wrong, it was mostly throwing out lines ending with the character "t". And sometimes I heard, when the time was right, it also used to throw out a bunch of lines starting with the character "t" followed by some whitespaces. 

In any case, the empty lines are usually caught by the max_length filter, which of course has a min length parameter :-)