### PR TITLE
Move sample command to opuscleaner-datasets

### DIFF
--- a/opuscleaner/datasets.py
+++ b/opuscleaner/datasets.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
 """Lists datasets given a directory. It works by scanning the directory and looking for gz files."""
+import asyncio
+import os
+import pprint
+import sys
 from glob import glob
 from itertools import groupby
-from pathlib import Path as Path
-from typing import Dict, List, Tuple
+from pathlib import Path
+from shutil import copyfileobj
+from tempfile import TemporaryFile
+from typing import Dict, List, Tuple, Iterable
 
-from opuscleaner.config import DATA_PATH
+from opuscleaner.config import DATA_PATH, SAMPLE_PY, SAMPLE_SIZE
 
 
 def list_datasets(path:str) -> Dict[str,List[Tuple[str,Path]]]:
@@ -39,13 +45,101 @@ def list_datasets(path:str) -> Dict[str,List[Tuple[str,Path]]]:
     }
 
 
-def main() -> None:
-    import sys
-    import pprint
-    if len(sys.argv) == 1:
-        pprint.pprint(list_datasets(DATA_PATH))
+def dataset_path(name:str, template:str) -> str:
+    # TODO: fix this hack to get the file path from the name this is silly we
+    # should just use get_dataset(name).path or something
+    root = DATA_PATH.split('*')[0]
+
+    # If the dataset name is a subdirectory, do some hacky shit to get to a
+    # .sample.gz file in said subdirectory.
+    parts = name.rsplit('/', maxsplit=2)
+    if len(parts) == 2:
+        root = os.path.join(root, parts[0])
+        filename = parts[1]
     else:
-        pprint.pprint(list_datasets(sys.argv[1]))
+        filename = parts[0]
+
+    return os.path.join(root, template.format(filename))
+
+
+def filter_configuration_path(name:str) -> str:
+    return dataset_path(name, '{}.filters.json')
+
+
+def sample_path(name:str, langs:Iterable[str]) -> str:
+    languages = '.'.join(sorted(langs))
+    return dataset_path(name, f'.sample.{{}}.{languages}')
+
+
+def main_list_commands(args):
+    print("Error: No command specified.\n\n"
+          "Available commands:\n"
+          "  list       list datasets\n"
+          "  sample     sample all datasets\n"
+          "", file=sys.stderr)
+    sys.exit(1)
+
+
+async def sample_all_datasets(args):
+    tasks = []
+
+    for name, columns in list_datasets(DATA_PATH).items():
+        langs = [lang for lang, _ in columns]
+        if not os.path.exists(sample_path(name, langs)) or args.force:
+            print(f"Sampling {name}...", file=sys.stderr)
+            tasks.append([name, columns])
+
+    for task, result in zip(tasks, await asyncio.gather(*[compute_sample(*task) for task in tasks], return_exceptions=True)):
+        if isinstance(result, Exception):
+            print(f"Could not compute sample for {task[0]}: {result!s}", file=sys.stderr)
+
+
+async def compute_sample(name:str, columns:List[Tuple[str,Path]]) -> None:
+    langs = [lang for lang, _ in columns]
+    with TemporaryFile() as tempfile:
+        proc = await asyncio.subprocess.create_subprocess_exec(
+            *SAMPLE_PY,
+            '-n', str(SAMPLE_SIZE),
+            *[str(file.resolve()) for _, file in columns],
+            stdout=tempfile,
+            stderr=asyncio.subprocess.PIPE)
+
+        _, stderr = await proc.communicate()
+
+        if proc.returncode != 0:
+            raise Exception(f'sample.py failed with exit code {proc.returncode}: {stderr.decode()}')
+
+        tempfile.seek(0)
+
+        with open(sample_path(name, langs), 'wb') as fdest:
+            copyfileobj(tempfile, fdest)
+
+
+def main_list(args):
+	pprint.pprint(list_datasets(args.path))
+
+
+def main_sample(args):
+    asyncio.run(sample_all_datasets(args))
+
+
+def main(argv=sys.argv):
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Fill up those seats on your empty train.')
+    parser.set_defaults(func=main_list_commands)
+    subparsers = parser.add_subparsers()
+
+    parser_serve = subparsers.add_parser('list')
+    parser_serve.add_argument('path', nargs="?", type=str, default=DATA_PATH)
+    parser_serve.set_defaults(func=main_list)
+
+    parser_sample = subparsers.add_parser('sample')
+    parser_sample.add_argument("--force", "-f", action="store_true")
+    parser_sample.set_defaults(func=main_sample)
+
+    args = parser.parse_args()
+    args.func(args)
 
 
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,23 +9,17 @@ readme = "README.md"
 requires-python = ">=3.9"
 license = "MIT"
 keywords = []
-authors = [
-  { name = "Jelmer van der Linde", email = "jelmer@ikhoefgeen.nl" },
-]
+authors = [{ name = "Jelmer van der Linde", email = "jelmer@ikhoefgeen.nl" }]
 classifiers = [
-  "Development Status :: 4 - Beta",
-  "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: Implementation :: CPython",
-  "Programming Language :: Python :: Implementation :: PyPy",
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dynamic = [
-  "version",
-  "dependencies",
-  "optional-dependencies"
-]
+dynamic = ["version", "dependencies", "optional-dependencies"]
 
 [project.scripts]
 opuscleaner-server = "opuscleaner.server:main"
@@ -33,6 +27,7 @@ opuscleaner-clean = "opuscleaner.clean:main"
 opuscleaner-col = "opuscleaner.col:main"
 opuscleaner-threshold = "opuscleaner.threshold:main"
 opuscleaner-sample = "opuscleaner.sample:main"
+opuscleaner-datasets = "opuscleaner.datasets:main"
 opuscleaner-download = "opuscleaner.download:main"
 
 [project.urls]
@@ -44,10 +39,7 @@ Source = "https://github.com/hplt-project/opuscleaner"
 path = "opuscleaner/__about__.py"
 
 [tool.hatch.envs.default]
-dependencies = [
-  "pytest",
-  "pytest-cov",
-]
+dependencies = ["pytest", "pytest-cov"]
 [tool.hatch.envs.default.scripts]
 cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=opuscleaner --cov=tests {args}"
 no-cov = "cov --no-cov {args}"
@@ -56,9 +48,7 @@ no-cov = "cov --no-cov {args}"
 python = ["39", "310", "311"]
 
 [tool.hatch.build]
-include = [
-  "/opuscleaner",
-]
+include = ["/opuscleaner"]
 
 [tool.hatch.build.force-include]
 "frontend/dist" = "/opuscleaner/frontend"
@@ -72,13 +62,7 @@ all = ["requirements-all.txt"]
 [tool.coverage.run]
 branch = true
 parallel = true
-omit = [
-  "opuscleaner/__about__.py",
-]
+omit = ["opuscleaner/__about__.py"]
 
 [tool.coverage.report]
-exclude_lines = [
-  "no cov",
-  "if __name__ == .__main__.:",
-  "if TYPE_CHECKING:",
-]
+exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]


### PR DESCRIPTION
Removes the subcommands from `opuscleaner-server`, adds `opuscleaner-datasets` which has `list` and `sample`.