### PR TITLE
Make OpusFilter RegexSub monolingual

### DIFF
--- a/opuscleaner/filters/opusfilter/RegExpSub.json
+++ b/opuscleaner/filters/opusfilter/RegExpSub.json
@@ -1,5 +1,5 @@
 {
-    "type": "bilingual",
+    "type": "monolingual",
     "name": "opus.RegExpSub",
     "description": "Apply regular expression substitutions",
     "command": "./opusfilter-ersatz.py --quiet opusfilter.preprocessors.RegExpSub \"$PARAMETERS_AS_YAML\"",


### PR DESCRIPTION
I think this filter has more sense being monolingual so it can be applied separately to each side.