### PR TITLE
Add currency mismatch filter

### DIFF
--- a/opuscleaner/filters/currency_mismatch.json
+++ b/opuscleaner/filters/currency_mismatch.json
@@ -1,0 +1,17 @@
+{
+    "type": "bilingual",
+    "description": "Compare currencies (symbols and ISO codes) on both sides",
+    "parameters": {
+        "DEBUG": {
+            "type": "bool",
+            "default": false,
+            "help": "Output deleted or fixed lines and extracted currencies to stderr"
+        },
+        "FIX": {
+            "type": "bool",
+            "default": false,
+            "help": "Attempt fixing target sentence where possible"
+        }
+    },
+    "command": "./currency_mismatch.py ${DEBUG:+--debug} ${FIX:+--fix}"
+}

--- a/opuscleaner/filters/currency_mismatch.py
+++ b/opuscleaner/filters/currency_mismatch.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Compare currencies (symbols and ISO codes) on both sides.
+Filter mismatches and optionally try fixing the target currency where possible.
+
+Example:
+    cat corpus.tsv | ./currency_mismatch.py --debug --fix > kept.tsv
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from typing import List, TextIO
+
+from babel.numbers import list_currencies, get_currency_symbol
+
+
+def build_currency_map() -> dict[str, set[str]]:
+    """Return ``{currency ID → set(ISO codes)}`` built from CLDR/Babel.
+
+    *currency* is a generic symbol (e.g. ``€``) or an ISO code (``EUR``).
+    """
+    cmap = defaultdict(set)
+
+    for iso in list_currencies():
+        cmap[iso].add(iso)  # ISO code itself
+        sym = get_currency_symbol(iso, "en")
+        # this captures all currencies that use $ (CA$ etc.)
+        if '$' in sym:
+            cmap['$'].add(iso)
+        cmap[sym].add(iso)
+
+    return dict(cmap)
+
+
+def compile_currency_regex(currencies: List[str]):
+    """
+    Compile a  regex that finds any currency symbol or ISO code near numbers,
+        but safely ignores text where those strings are just a part of another word.
+    """
+    escaped = sorted(map(re.escape, currencies), key=len, reverse=True)
+    number = r'\d[\d.,]*'  # 5   1,234.56   9.99
+    cur_ids = '|'.join(escaped)  # same escaped ISO/symbol list as before
+
+    pattern = re.compile(
+        rf"""(?x)
+            (?<![A-Za-z])                  # no letter on the left
+            (?:
+                (?P<tok1>{cur_ids})\s*{number}    # token before number
+              |
+                {number}\s*(?P<tok2>{cur_ids})    # number before token
+            )
+            (?![A-Za-z])                   # no letter on the right
+        """
+    )
+
+    return re.compile(pattern)
+
+
+CMAP = build_currency_map()
+RGX = compile_currency_regex(list(CMAP.keys()))
+
+
+def _kind(cur: str) -> str:
+    """Return ``'symbol'`` if currency has **no letters**, else ``'code'``."""
+    return "symbol" if not any(c.isalpha() for c in cur) else "code"
+
+
+def check_row(
+        src: str,
+        trg: str,
+        fix: bool = False,
+        debug: bool = False,
+):
+    """Validate and fixes a sentence pair.
+
+    Returns ``(flag: bool, fixed_trg: str)``.
+
+    * **flag == True** when either
+        – the two sentences include *different* currencies or the order doesn't match
+        – they include the same currencies but use different styles (e.g. symbol and ISO code)
+
+    * When ``fix`` is **True** and the styles of mismatched currencies match, the target is replaced with the source
+    """
+    src_curs = [t1 or t2 for t1, t2 in RGX.findall(src)]
+    trg_curs = [t1 or t2 for t1, t2 in RGX.findall(trg)]
+    src_isos = [CMAP[cur] for cur in src_curs]
+    trg_isos = [CMAP[cur] for cur in trg_curs]
+    src_styles = [_kind(cur) for cur in src_curs]
+    trg_styles = [_kind(cur) for cur in trg_curs]
+
+    flag = False
+    if src_isos != trg_isos or src_styles != trg_styles:
+        flag = True
+
+    new_trg = None
+    # Optional auto‑fix of the simplest case (single instance, different ISO codes, same style)
+    # It's possible to fix it when the styles also don't match but it leads to incorrect formatting,
+    # for example 5 USD -> 5 $ instead of $5
+    if fix and flag and len(src_curs) == len(trg_curs) == 1 and src_styles[0] == trg_styles[0]:
+        new_trg = trg.replace(trg_curs[0], src_curs[0])
+
+    if flag and debug:
+        print(f"L: {src_curs}  R: {trg_curs} LINE: {src}\t{trg}{' FIXED: ' + new_trg if new_trg else ''}",
+              file=sys.stderr)
+
+    return flag, new_trg
+
+
+def filter_currency_mismatch(fin: TextIO, fout: TextIO, debug: bool = False, fix: bool = False) -> None:
+    for line in fin:
+        cols = line.rstrip("\r\n").split("\t")
+        assert len(cols) >= 2, "Input must have at least two tab-separated columns"
+
+        src, trg = cols[0], cols[1]
+        flag, fixed = check_row(src, trg, fix=fix, debug=debug)
+
+        if not flag:
+            fout.write(line)
+        elif fix and fixed:
+            fout.write(f"{src}\t{fixed}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Compare currencies (symbols and ISO codes) on both sides. Optionally try fixing the target currency where possible."
+    )
+    parser.add_argument(
+        "--debug", action="store_true", help="Output deleted lines and extracted currencies to stderr"
+    )
+    parser.add_argument(
+        "--fix", action="store_true", help="Attempt fixing target sentence where possible"
+    )
+    args = parser.parse_args()
+
+    filter_currency_mismatch(sys.stdin, sys.stdout, debug=args.debug, fix=args.fix)

--- a/opuscleaner/filters/test_currency_mismatch.py
+++ b/opuscleaner/filters/test_currency_mismatch.py
@@ -1,0 +1,201 @@
+import io
+import unittest
+from typing import Optional
+
+from currency_mismatch import filter_currency_mismatch
+
+accept_examples = [
+    # wrong numbers but correct currencies
+    (
+        'Base costs: Price: 25,410.00 € Price per 7 days Base costs: Base costs: 0.00 € More about the vessel »',
+        'Kostenlos: Außenborder, Preis: 7.260,00 € Preis für 7 Tage Basiskosten: Basiskosten: 0,00 € Mehr über das Produkt »'
+    ),
+
+    # This is very rare and the regex captures only EUR near the number
+    # £/$/€ -> €
+    (
+        'Players must make a minimum deposit of at least £/$/€ 100 to get a 50% up to £/$/€ 200 match bonus using code: 2017.',
+        'Spieler müssen eine Einzahlung von mindestens 100 € machen, um einen Bonus von 50 % bis zu 200 € zu erhalten, wenn sie den Code: 2017 angeben.'
+    ),
+
+]
+
+reject_examples = [
+
+    # wrong number and currency
+    (
+        '1 of 16 B&Bs and Inns in Belfast From £75 per night.',
+        'Nr. 1 von 16 Bed & Breakfasts und Gasthäusern in Belfast Ab € 85 pro Nacht.',
+        'Nr. 1 von 16 Bed & Breakfasts und Gasthäusern in Belfast Ab £ 85 pro Nacht.'
+    ),
+
+    # $ -> EUR
+    (
+        'That’s $1200 a year that you could be saving.',
+        'Das wären 1200 EUR, die du pro Jahr abzahlen kannst.',
+        None
+    ),
+
+    # $ -> EUR
+    (
+        'RELATED: How to Add $5,000 to Your Savings By the End of the Year',
+        'Wie Sie bis Ende des Jahres 5.000 EUR zu Ihren Ersparnissen hinzufügen können',
+        None
+    ),
+
+    # $ -> Euro
+    (
+        'The cost to the city: $100,000.',
+        'Die jährlichen Kosten für die Stadt: 100.000 Euro.',
+        None
+    ),
+
+    # $ -> Euro
+    (
+        'The cost to the city: 100,000 USD.',
+        'Die jährlichen Kosten für die Stadt: 100.000 EUR.',
+        'Die jährlichen Kosten für die Stadt: 100.000 USD.'),
+
+    # $ -> Euro
+    (
+        'So you get $500 in healthcare.',
+        'Also bekommst du 500 Euro im Gesundheitswesen.',
+        None),
+
+    # $ -> €
+    (
+        'Assassin’s Creed Chronicles: India is the second installment of the series after Assassin’s Creed® Chronicles: China and is available for $9.99.',
+        'Assassin’s Creed® Chronicles: India ist nach Assassin’s Creed® Chronicles: China die zweite Episode der Serie und für 9,99 € erhältlich.',
+        'Assassin’s Creed® Chronicles: India ist nach Assassin’s Creed® Chronicles: China die zweite Episode der Serie und für 9,99 $ erhältlich.'),
+
+    # $ -> CAD (Canadian dollar also uses $)
+    (
+        'These results represent a 280 percent increase in revenue over the previous fiscal year ($368,536) and a 286 percent increase of fourth quarter sales year over year, from $99,331 to $383,844.',
+        'Diese Ergebnisse bedeuten eine Steigerung des Umsatzes um 280 % gegenüber dem Vorjahr (368.536 CAD) und eine Steigerung des Umsatzes im vierten Quartal um 286 % im Jahresvergleich von 99.331 CAD auf 383.844 CAD.',
+        None
+    ),
+
+    # $ AUD -> AUD
+    (
+        'The Arthur scooter is designed to be economical and consumes just about $1 AUD per week with average daily usage.',
+        'Der Roller ist sparsam konzipiert und verbraucht bei durchschnittlichem Tagesverbrauch nur etwa 1 AUD pro Woche.',
+        None),
+
+    # $ -> _ No currency
+    (
+        'Qualcomm Must Refund BlackBerry $815 Million in Fees',
+        'Qualcomm soll Blackberry über 815 Millionen zahlen',
+        None),
+
+    # $ -> USD almost correct but it should be $ (very common!)
+    (
+        'Below this level, the next critical support is $66.1486.',
+        'Unterhalb dieses Niveaus liegt die nächste Schlüsselunterstützung bei 66,1486 USD.',
+        None
+    ),
+
+    # $ -> US-Dollar almost correct but it should be $ (very common!)
+    (
+        'College Students Can Now Get Sirius XM for $4 a Month',
+        'College-Studenten können jetzt Sirius XM für 4 US-Dollar pro Monat erwerben',
+        None
+    ),
+
+    # $ -> Dollar
+    (
+        'Look, according to expert analyses, Russia fell short by about $50 billion as a result of these restrictions during these years, starting in 2014.',
+        'Schauen Sie, nach Angaben von Experten hat Russland als Folge all dieser Beschränkungen in den Jahren seit 2014 etwa 50 Milliarden Dollar verloren.',
+        None
+    ),
+
+    # $ + USD -> USD
+    (
+        'If your own travel insurance does not include liability coverage up to $1,000,000 USD, we can offer this to you for an additional $12.25/day.',
+        'Wenn Ihre Reiseversicherung keine Haftpflichtversicherung in Höhe von 1.000.000 USD umfasst, können wir Ihnen diese zusätzlich für 12,25 USD pro Tag anbieten.',
+        None
+    ),
+
+    # £ -> Britischen Pfund
+    (
+        'Up to 64 teams will compete for a total prize pool of up to £5,000!',
+        'Bis zu 64 Teams werden um einen Gesamtpreis in Höhe von bis zu 5.000 Britischen Pfund kämpfen!',
+        None
+    ),
+
+    # £ -> €
+    (
+        'ABOUT US Get the scoop first and get £15 and a free pattern',
+        'Erhalte als Erster alle Neuigkeiten, einen 15 €-Gutschein und eine kostenlose Anleitung',
+        'Erhalte als Erster alle Neuigkeiten, einen 15 £-Gutschein und eine kostenlose Anleitung'
+    ),
+
+    # LTL -> лит, EURO -> EUR, LTL -> лита
+    (
+        'Prizes: Prize fund - 4000 LTL (1 EURO ~3.45 LTL)',
+        'ПРИЗОВОЙ ФОНД - 4000 лит (1 EUR = 3,45 лита)',
+        None
+    )
+]
+
+
+class TestCurrencyMismatch(unittest.TestCase):
+    def _test(self, line: str, **kwargs) -> Optional[str]:
+        fin = io.StringIO(line)
+        fout = io.StringIO()
+        filter_currency_mismatch(fin, fout, **kwargs)
+        return fout.getvalue()
+
+    def assertAccept(self, line: str, **kwargs):
+        """Test that this line is accepted"""
+        self.assertTrue(self._test(line, **kwargs) == line)
+
+    def assertReject(self, line: str, **kwargs):
+        """Test that this line is rejected"""
+        self.assertTrue(self._test(line, **kwargs) == "")
+
+    def assertFixed(self, line: str, fixed_trg: str, **kwargs):
+        """Test that this line was fixed"""
+        output = self._test(line, **kwargs)
+        src = line.split("\t")[0]
+        fixed_line = f'{src}\t{fixed_trg}' if fixed_trg else ""
+        self.assertTrue(output == fixed_line)
+
+    def test_match(self):
+        """Exact matches should be accepted."""
+        self.assertAccept('Purchase options 5$ are great\tSomething else 5 $ hello', fix=False)
+
+    def test_accept_no_number(self):
+        """Exact matches should be accepted."""
+        self.assertAccept('Purchase options $ are great\tSomething else EUR hello', fix=False)
+
+    def test_mismatch(self):
+        """Exact matches should be accepted."""
+        self.assertReject('Purchase options 5$ are great\tSomething else 5 £ hello', fix=False)
+
+    def test_fix(self):
+        """Exact matches should be accepted."""
+        self.assertFixed('Purchase options 5$ are great\tSomething else 5 £ hello',
+                         'Something else 5 $ hello', fix=True)
+
+    def test_different_iso_and_style(self):
+        """Exact matches should be accepted."""
+        self.assertReject('Purchase options 5$ are great\tSomething else 5 EUR hello',
+                          fix=True)
+
+    def test_symbol_code_mismatch(self):
+        """Exact matches should be accepted."""
+        self.assertReject('Purchase options 5$ are great\tSomething else 5 USD hello',
+                          fix=True)
+
+    def test_reject_examples_no_fix(self):
+        for src, trg, _ in reject_examples:
+            self.assertReject(f'{src}\t{trg}', fix=False)
+
+    def test_accept_example(self):
+        for src, trg in accept_examples:
+            self.assertAccept(f'{src}\t{trg}', fix=True)
+
+    def test_fix_examples(self):
+        for src, trg, fixed in reject_examples:
+            print(src)
+            self.assertFixed(f'{src}\t{trg}', fixed, fix=True)

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -10,3 +10,4 @@ sacremoses
 spacy-pkuseg
 more_itertools
 requests
+Babel


### PR DESCRIPTION
Filters and fixes currency mismatch for simple cases (matches symbols like `$` and currency ISO codes like `CAD`).

It applies a fix only if it's a single currency per sentence and it has the same style (two symbols or two codes). Fixing different style leads to teaching a model to use incorrect formatting like 5 $ instead of $5.


The code allows experimenting with more complex implementation as it's for example aware of $ mapping to USD, CAD, AUD etc. So if we think if filters too much we could leave filtering by ISO code, then it wouldn't filter $ - USD, EUR - €.
I ended up with handling only the simplest cases as the complexity grows too much if we try handling more, for example, words like "dollar" (trickier for languages with high morphological complexity). Looking at en-ru in OpusCleaner I noticed it filters quite a lot "$/USD -> доллар(ов)" like cases, so I wonder if there are some cultural differences in how to report currencies. Maybe non-Latin languages use Latin ISO codes less, not sure.


I ran it on 1M sample for our en-de data, and it filtered just 3000 sentences and fixed 121.

Filtered examples:

```
[0:currency_mismatch] L: ['€']  R: [] LINE: The accolade, which is worth up to € 2.5 million, is Germany’s most prestigious research prize.	Die mit bis zu 2,5 Millionen Euro dotierte Auszeichnung gilt als wichtigster Forschungsförderpreis in Deutschland.
[0:currency_mismatch] L: ['€']  R: [] LINE: European Union members between 18 and 25 years: 7.50 €	EU-Bürger zwischen 18 und 25 Jahren: 7,50 Eur
[0:currency_mismatch] L: ['$']  R: [] LINE: That some of the reported $16 billion Saudi payment to Israel was going to finance Israeli settlements on the Palestinian West Bank would further reflect this Saudi indifference.	Dass mindestens ein Teil der 16 Milliarden $ der Zahlungen Saudi-Arabiens an Israel, dazu benutzt wurde, um israelische Siedlungen auf der West-Bank zu bauen, zeigt darüber hinaus die Gleichgültigkeit der Saudis, gegenüber dem Schicksal der Palästinenser.
[0:currency_mismatch] L: ['$']  R: ['USD'] LINE: No, of course, it’s hard to quit smoking, but if you smoke you can see pack and a half, which is about $ 3,000 a year, and savings amounted to quit smoking.	Nein, es ist sicherlich nicht leicht aufzuhören, aber wenn Sie anderthalb Packungen pro Tag rauchen, belaufen sich die Einsparungen auf fast 3.000 USD pro Jahr, wenn Sie aufhören.
[0:currency_mismatch] L: ['USD']  R: [] LINE: -relatively high annual state fees, between 160,000 and 400,000 USD.	-Relativ hohe jährliche staatliche Gebühren, zwischen 160.000- 400.000 CI$.
[0:currency_mismatch] L: ['$']  R: ['USD'] LINE: The Royal Canadian Mint has unveiled its new $1 "equality coin," honoring the progress of civil rights for LGBTI Canadians, Gay Star News noted.	Die Royal Canadian Mint hat ihre neue "Gleichheitsmünze" in Höhe von 1 USD vorgestellt, mit der die Fortschritte der Bürgerrechte für "LGBTQ2" -Kanierer gewürdigt werden.
[0:currency_mismatch] L: ['$']  R: [] LINE: In honor of the 50th anniversary of the moon landing, Neon`s documentary "Apollo 11" returned to theaters, making $75,000 from 107 venues.	Zu Ehren des 50. Jahrestages der Mondlandung kehrte Neons Dokumentarfilm "Apollo 11" in die Kinos zurück und verdiente 75.000 US-Dollar an 107 Orten.
[0:currency_mismatch] L: ['€', '€']  R: [] LINE: SAP HANA Success Continued in 2013: Full Year 2013 HANA Software Revenue Increased 69% at Constant Currencies to €664 Million (61% at Actual Currencies to €633 Million), SAP HANA Becomes the Real-Time Platform for the Industry	Erfolg von SAP HANA setzt sich fort: HANA-Softwareumsatz wuchs im Gesamtjahr 2013 währungsbereinigt um 69 % auf 664 Mio. € (um 61 % auf 633 Mio. € zu aktuellen Kursen), SAP HANA wird die Plattform für Echtzeit-Unternehmensanwendungen für die IT-Branche
[0:currency_mismatch] L: ['$']  R: [] LINE: From 1997 to 2000 the sum in the Ledbury portfolio grew to more than $300 million.	Von 1997 bis 2000 wuchs die Summe im Ledbury-Portfolio auf mehr als 300 Millionen Dollar an.
[0:currency_mismatch] L: ['$']  R: [] LINE: British Bitcoin Hacker Sentenced to 10 Years For Stealing $600,000 in Bitcoin	Britischer Hacker zu 10 Jahren verurteilt wegen Diebstahls von 600.000 Dollar in Bitcoin
[0:currency_mismatch] L: ['€', '$']  R: ['$', '$'] LINE: #2 - Generous Welcome Bonus: A 200% match on your first deposit up to €1.5k + $20 extra free cash with my Titan Poker bonus code SNGPLANET is not only one of the biggest sign-up bonuses around, it is also one of the fastest to clear!	#2 – Großzügiger Willkommensbonus: Ein 200% Willkommensbonus auf Ihre erste Einzahlung bis $2000 sowie $20 extra Bares bei Titan Poker mit dem Bonuscode SNGPLANET, das ist nicht nur einer der größten Anmeldeboni überhaupt sondern auch einer der schnellsten beim Clearing!
[0:currency_mismatch] L: ['£']  R: [] LINE: NATS, the UK’s leading provider of air traffic services and solutions, today has released findings of the first three operational months of its world-first environmental flight efficiency metric, which is designed to deliver 600,000 tonnes of CO2 savings over the next three years, worth up to £120m in today’s fuel prices.	NATS, der führende Anbieter von Flugverkehrsdiensten und -lösungen in Großbritannien, veröffentlichte heute die Ergebnisse aus den ersten drei Betriebsmonaten seines weltweit ersten Messsystems für umweltfreundliche Flugeffizienz, das dazu dient, in den nächsten drei Jahren 600.000 Tonnen CO2-Einsparungen zu generieren.
[0:currency_mismatch] L: []  R: ['EUR'] LINE: A Long Way Down [Blu-ray] 8,97	Der letzte Akt [Blu-ray] 8,97 EUR
[0:currency_mismatch] L: ['€']  R: ['CHF'] LINE: Finance from €0.00 per month Powerful & Energetic Fairly Heavy Feel	Kredit-Finanzierung ab CHF 0,00 pro Monat Leistungsstark und energisch.
[0:currency_mismatch] L: ['$']  R: [] LINE: Over the course of six years, from 1939 to 1945, more than $2 billion were spend during the history of the Manhattan Project.	Im Laufe von sechs Jahren, von 1939 bis 1945, wurden mehr als 2 Milliarden Dollar für das Manhattan-Projekt ausgegeben.
[0:currency_mismatch] L: []  R: ['€'] LINE: Year of manufacture: 2017, Lights, Working width: 3.00 m, Diameter: 750 mm, Weight: 1450 kg, Trailed tillage equipment	Baujahr: 2017, Beleuchtung, Arbeitsbreite: 3.00 m, Durchmesser: 750 mm, Gewicht: 1450 kg, Nachläufer Bodenbearbeitungsgerät 4.013 €
[0:currency_mismatch] L: ['€']  R: [] LINE: Despite adverse currency effects and higher material costs in the capital goods businesses, the Group increased its adjusted EBIT significantly year-on-year by 21 percent to €500 million.	Trotz gegenläufiger Währungseffekte und gestiegener Materialkosten bei den Industriegütergeschäften steigerte der Konzern das Bereinigte EBIT gegenüber dem Vorjahr deutlich um 21 Prozent auf 500 Mio €.
[0:currency_mismatch] L: ['CHF']  R: [] LINE: Migros invests more than CHF 17 million in improving the 57-hectare park.	Die Migros investiert mehr als 17 Millionen Franken in den Ausbau des 57 Hektar grossen Parks.
[0:currency_mismatch] L: []  R: ['USD'] LINE: GBP/USD Four-Hour Chart: Bounce to Resistance at Prior Support 1.3304	GBP/USD – Vier-Stunden-Chart: Sprung zu Widerstand an vorheriger Unterstützung bei 1,3304 USD
[0:currency_mismatch] L: ['$']  R: [] LINE: Over $300 million worth of tuna, shrimp, and lobster are reportedly being stolen every year by illegal trawlers off Somalia’s coast.	Für mehr als 300 Millionen US-Dollar Thunfisch, Garnelen, Hummer und andere Meerestiere werden jedes Jahr von großen Trawlers aus Somalias ungeschützten Meeren gestohlen.
```

For de-en it also filters a lot of code/symbol-word mismatches like $300 - 300 Millionen US-Dollar

Fixed examples:
```
[0:currency_mismatch] L: ['USD']  R: ['CHF'] LINE: • 8 2-star hotels from 9 USD per night	• 9 2-Sterne-Hotels ab CHF 8 pro Nacht FIXED: • 9 2-Sterne-Hotels ab USD 8 pro Nacht
[0:currency_mismatch] L: ['$']  R: ['€'] LINE: Shopping cart 0 / $ 0.00 Shop Mono machining	Warenkorb 0 / 0,00 € Shop Monozerspanung FIXED: Warenkorb 0 / 0,00 $ Shop Monozerspanung
[0:currency_mismatch] L: ['£']  R: ['€'] LINE: In addition, we'll pay you £5 for each friend who registers as a VIP Lounge member after they have been a member for 30 days.	Zusätzlich zahlen wir dir 5 € für jeden Freund, der sich als VIP Lounge Mitglied registriert, sobald seine Mitgliedschaft 30 Tage lang besteht. FIXED: Zusätzlich zahlen wir dir 5 £ für jeden Freund, der sich als VIP Lounge Mitglied registriert, sobald seine Mitgliedschaft 30 Tage lang besteht.
[0:currency_mismatch] L: ['$']  R: ['€'] LINE: Each session costs $120.	Jede Sitzung kostet € 120. FIXED: Jede Sitzung kostet $ 120.
[0:currency_mismatch] L: ['£']  R: ['€'] LINE: Mounting: Includes a high-quality aluminium wall mounting worth £9.99	Aufhängung: Inklusive hochwertiger Aluminiumaufhängung im Wert von 9,99€ FIXED: Aufhängung: Inklusive hochwertiger Aluminiumaufhängung im Wert von 9,99£
[0:currency_mismatch] L: ['$']  R: ['€'] LINE: It is important at this stage to note that when they say $50 FREE they really do mean free as there is no purchase required for this bonus.	An dieser Stelle ist es wichtig zu betonen, dass wenn sie sagen 50€ GRATIS, sie auch wirklich gratis meinen, denn um den Bonus zu erhalten, ist absolut keine Einzahlung erforderlich. FIXED: An dieser Stelle ist es wichtig zu betonen, dass wenn sie sagen 50$ GRATIS, sie auch wirklich gratis meinen, denn um den Bonus zu erhalten, ist absolut keine Einzahlung erforderlich.
[0:currency_mismatch] L: ['CAD']  R: ['EUR'] LINE: Chennai hostels and hotels with a 2 star rating and below charge around 11 CAD for a bed per person.	In Hostels (bzw. Hotels mit einer Bewertung von bis zu 2 Sternen) in Chennai zahlst du in etwa 11 EUR pro Person. FIXED: In Hostels (bzw. Hotels mit einer Bewertung von bis zu 2 Sternen) in Chennai zahlst du in etwa 11 CAD pro Person.
[0:currency_mismatch] L: ['$']  R: ['€'] LINE: The image "water flow effect1" from 2jenn is available on Fotolia under a royalty-free license from 1 credit (Credit from $0.74).	Das Bild "water flow effect1" von 2jenn ist bei Fotolia lizenzfrei ab 1 Credit erhältlich (Credit ab 0,74 €). FIXED: Das Bild "water flow effect1" von 2jenn ist bei Fotolia lizenzfrei ab 1 Credit erhältlich (Credit ab 0,74 $).
[0:currency_mismatch] L: ['$']  R: ['€'] LINE: Click here to buy 2 tickets at special price of $96:	für den Kauf von zwei Produkten zu einem Gesamtpreis von € 96,--: FIXED: für den Kauf von zwei Produkten zu einem Gesamtpreis von $ 96,--:
[0:currency_mismatch] L: ['£']  R: ['€'] LINE: Genius Media Pointer 100 £19.90 In stock > 10 pcs Buy 4.5	Genius Media-Pointer 100 22,90 € Auf Lager > 10 Stück Kaufen 4,5 FIXED: Genius Media-Pointer 100 22,90 £ Auf Lager > 10 Stück Kaufen 4,5
[0:currency_mismatch] L: ['$']  R: ['€'] LINE: Bonus $1000 + 200 Free Spins	200 Freispiele und 1000€ Bonus-Paket FIXED: 200 Freispiele und 1000$ Bonus-Paket
[0:currency_mismatch] L: ['$']  R: ['€'] LINE: Plus another $30 from other things.	Sind immerhin 30€ mehr für andere Dinge. FIXED: Sind immerhin 30$ mehr für andere Dinge.
[0:currency_mismatch] L: ['£']  R: ['€'] LINE: If a driver reserves a DriiveMe trip, at least 15 days after clicking your link, you receive a £10 voucher.	Falls ein Fahrer eine DriiveMe-Fahrt reserviert, erhalten Sie mindestens 15 Tage nach dem Anklicken Ihres Links einen €10 Gutschein. FIXED: Falls ein Fahrer eine DriiveMe-Fahrt reserviert, erhalten Sie mindestens 15 Tage nach dem Anklicken Ihres Links einen £10 Gutschein.
[0:currency_mismatch] L: ['$']  R: ['€'] LINE: KAYAK users have found double rooms in United States for as cheap as $12 (Chicago) in the last 3 days.	KAYAK-Nutzer haben Doppelzimmer in USA bereits ab 12 € (Chicago) in den letzten 3 Tagen gefunden. FIXED: KAYAK-Nutzer haben Doppelzimmer in USA bereits ab 12 $ (Chicago) in den letzten 3 Tagen gefunden.
[0:currency_mismatch] L: ['£']  R: ['€'] LINE: 200% match bonus up to £100! Currency	200% Matchbonus bis zu 100 €! Währung FIXED: 200% Matchbonus bis zu 100 £! Währung
[0:currency_mismatch] L: ['$']  R: ['€'] LINE: Is that not worth $50 per month?	Ist Ihnen das nicht 50 € im Jahr wert? FIXED: Ist Ihnen das nicht 50 $ im Jahr wert?
[0:currency_mismatch] L: ['$']  R: ['€'] LINE: Extra person $ 10,00 per night (children as extra person up to 2 years old stay for free, children bed at no extra charge).	Zusätzliche person €10,00 pro Nacht (Kinder als zusätzliche Person bis zu 2 Jahren übernachten kostenfrei, Kinder Bett ohne Aufpreis). FIXED: Zusätzliche person $10,00 pro Nacht (Kinder als zusätzliche Person bis zu 2 Jahren übernachten kostenfrei, Kinder Bett ohne Aufpreis).
[0:currency_mismatch] L: ['£']  R: ['€'] LINE: £15.99, 30×20 cm, In Stock! +4 Other sizes tennis ball on a tennis court	20,99 €, 30×20 cm, Sofort lieferbar! +4 Weitere Größen Snowboarder Gleiten auf einer Schiene FIXED: 20,99 £, 30×20 cm, Sofort lieferbar! +4 Weitere Größen Snowboarder Gleiten auf einer Schiene
[0:currency_mismatch] L: ['$']  R: ['€'] LINE: It is easily reached by tuk-tuk which costs in the region of $1	Die Anlage erreicht ihr recht einfach mit dem Tuk-Tuk, die Kosten liegen bei 1 €. FIXED: Die Anlage erreicht ihr recht einfach mit dem Tuk-Tuk, die Kosten liegen bei 1 $.
[0:currency_mismatch] L: ['USD']  R: ['TRY'] LINE: Rollaway bed fee: USD 30 per day	Parken ohne Parkservice: 30 TRY pro Tag FIXED: Parken ohne Parkservice: 30 USD pro Tag
```

I added some interesting examples that I found earlier to unit tests.

Related to https://github.com/mozilla/translations/issues/577


